### PR TITLE
Implement login state and greet user

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/org/ato/project/Auth.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/ato/project/Auth.kt
@@ -10,6 +10,9 @@ external fun getAuth(app: JsAny? = definedExternally): JsAny
 @JsName("signInWithPopup")
 external fun signInWithPopup(auth: JsAny, provider: JsAny): Promise<JsAny>
 
+@JsName("signOut")
+external fun signOut(auth: JsAny): Promise<JsAny>
+
 @JsName("GoogleAuthProvider")
 external class GoogleAuthProvider : JsAny
 

--- a/composeApp/src/wasmJsMain/kotlin/org/ato/project/screens/home/HomeScreen.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/ato/project/screens/home/HomeScreen.kt
@@ -17,7 +17,10 @@ fun HomeScreen(
     onNavigateToAdjectives: () -> Unit = { /* Fallback */ },
     onNavigateToNouns: () -> Unit = { /* Fallback */ },
     navController: NavController? = null,
-    onLogin: () -> Unit
+    userName: String? = null,
+    isLoggedIn: Boolean = false,
+    onLogin: () -> Unit,
+    onLogout: () -> Unit
 ) {
     // Define categories with their items
     val categories = listOf(
@@ -117,11 +120,13 @@ fun HomeScreen(
     // Use the NavigationTemplate component
     NavigationTemplate(
         title = "English Learning App",
-        subtitle = "Выберите раздел для изучения",
+        subtitle = userName?.let { "Привет, $it!" } ?: "Выберите раздел для изучения",
         categories = categories,
         actions = {
-            Button(onClick = onLogin) {
-                Text("Login")
+            if (isLoggedIn) {
+                Button(onClick = onLogout) { Text("Logout") }
+            } else {
+                Button(onClick = onLogin) { Text("Login") }
             }
         }
     )


### PR DESCRIPTION
## Summary
- add `signOut` JS interop to Auth
- manage login state in `App` and display login/logout buttons
- greet logged-in user in HomeScreen

## Testing
- `./gradlew build -x wasmJsBrowserTest -x allTests`

------
https://chatgpt.com/codex/tasks/task_e_688cd82055f483259b69a114740797fb