### PR TITLE
Enable Firebase auth persistence

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/org/ato/project/App.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/ato/project/App.kt
@@ -299,12 +299,19 @@ fun loginWithGoogle(onResult: (Boolean) -> Unit = {}) {
         val provider = GoogleAuthProvider()
         println("Login with Google2")
 
-        signInWithPopup(auth, provider).then({ _: JsAny ->
-            println("Login successful ${getUserDisplayName()}")
-            onResult(true)
+        setPersistence(auth, browserLocalPersistence).then({ _: JsAny ->
+            signInWithPopup(auth, provider).then({ _: JsAny ->
+                println("Login successful ${getUserDisplayName()}")
+                onResult(true)
+                null
+            }, { error: JsAny ->
+                println("Login error: ${error ?: error.toString()}")
+                onResult(false)
+                null
+            })
             null
         }, { error: JsAny ->
-            println("Login error: ${error ?: error.toString()}")
+            println("Persistence error: ${error ?: error.toString()}")
             onResult(false)
             null
         })

--- a/composeApp/src/wasmJsMain/kotlin/org/ato/project/Auth.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/ato/project/Auth.kt
@@ -13,6 +13,12 @@ external fun signInWithPopup(auth: JsAny, provider: JsAny): Promise<JsAny>
 @JsName("signOut")
 external fun signOut(auth: JsAny): Promise<JsAny>
 
+@JsName("setPersistence")
+external fun setPersistence(auth: JsAny, persistence: JsAny): Promise<JsAny>
+
+@JsName("browserLocalPersistence")
+external val browserLocalPersistence: JsAny
+
 @JsName("GoogleAuthProvider")
 external class GoogleAuthProvider : JsAny
 

--- a/composeApp/src/wasmJsMain/kotlin/org/ato/project/initializeApp.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/ato/project/initializeApp.kt
@@ -5,6 +5,10 @@ import androidx.compose.runtime.LaunchedEffect
 
 import org.ato.project.firebase.getAnalytics
 import org.ato.project.firebase.initializeApp
+// Auth related imports
+import org.ato.project.browserLocalPersistence
+import org.ato.project.getAuth
+import org.ato.project.setPersistence
 import kotlin.js.JsAny
 
 
@@ -34,6 +38,15 @@ fun Configure() {
             firebaseApp = initializeApp(firebaseConfig)
             val analytics = getAnalytics(firebaseApp)
             println("Firebase initialized successfully $firebaseApp")
+
+            val auth = getAuth(firebaseApp)
+            setPersistence(auth, browserLocalPersistence).then({ _: JsAny ->
+                println("Auth persistence configured")
+                null
+            }, { error: JsAny ->
+                println("Auth persistence error: ${'$'}{error ?: error.toString()}")
+                null
+            })
 
         } catch (e: Throwable) {
             println("Firebase init error: ${e.message}")


### PR DESCRIPTION
## Summary
- ensure Firebase auth uses local persistence
- configure persistence when logging in and on startup

## Testing
- `./gradlew build` *(fails: Errors occurred during launch of browser for testing)*

------
https://chatgpt.com/codex/tasks/task_e_688cf47b657c8325988a461c7c20ba17